### PR TITLE
Linker script update

### DIFF
--- a/Core/Inc/camera_application.h
+++ b/Core/Inc/camera_application.h
@@ -17,8 +17,11 @@
 #include "stdlib.h"
 #include "string.h"
 
-#define CAMERA_FRAME_BUFFER               0xC0260000
-#define LCD_FRAME_BUFFER                  0xC0130000
+#define CAM_FB_SIZE 259200
+uint8_t cam_fb[CAM_FB_SIZE] __attribute__ ((section (".sdram"), aligned (4)));
+
+#define LCD_FB_SIZE CAM_FB_SIZE
+char lcd_fb[LCD_FB_SIZE] __attribute__ ((section (".sdram"), aligned (4)));
 
 void initialiseCapture(void);
 void BSP_CAMERA_LineEventCallback(void);

--- a/Core/Src/camera_application.c
+++ b/Core/Src/camera_application.c
@@ -12,23 +12,20 @@ DMA2D_HandleTypeDef hdma2d_eval;
 uint32_t  *ptrLcd;
 uint8_t status = CAMERA_OK;
 
-uint8_t *cam_fb;
-uint32_t cam_fb_size;
-
 
 void LCD_init(void) {
 
 	BSP_LCD_Init();
 	uint32_t  *ptrLcd;
 	/* Init LCD screen buffer */
-	ptrLcd = (uint32_t*)(LCD_FRAME_BUFFER);
+	ptrLcd = (uint32_t*)(lcd_fb);
 	for (int i=0; i<(BSP_LCD_GetXSize()*BSP_LCD_GetYSize()); i++)
 	{
 	ptrLcd[i]=0;
 	}
 
-	BSP_LCD_LayerDefaultInit(LTDC_ACTIVE_LAYER, LCD_FRAME_BUFFER);
-	//BSP_LCD_LayerRgb565Init(LTDC_ACTIVE_LAYER, LCD_FRAME_BUFFER);
+	BSP_LCD_LayerDefaultInit(LTDC_ACTIVE_LAYER, lcd_fb);
+	//BSP_LCD_LayerRgb565Init(LTDC_ACTIVE_LAYER, lcd_fb);
 
 	/* Set LCD Foreground Layer  */
 	BSP_LCD_SelectLayer(LTDC_ACTIVE_LAYER);
@@ -40,14 +37,14 @@ void initialiseCapture(void) {
     //cam_fb_size = 480*272*2;			// Resolution * color depth; RGB565=16bit=2byte
     //cam_fb = (uint8_t *) malloc(cam_fb_size);
 
-    memset(CAMERA_FRAME_BUFFER, 255, cam_fb_size);
+    memset(cam_fb, 255, CAM_FB_SIZE);
 
 	BSP_CAMERA_Init(CAMERA_R480x272);
-	BSP_CAMERA_ContinuousStart((uint8_t *)CAMERA_FRAME_BUFFER);
+	BSP_CAMERA_ContinuousStart(cam_fb);
 }
 
 BSP_CAMERA_VsyncEventCallback(void) {
-	LCD_DMA_Transfer_RGBTOARGB8888((uint32_t *)(CAMERA_FRAME_BUFFER), (uint32_t *)(LCD_FRAME_BUFFER));
+	LCD_DMA_Transfer_RGBTOARGB8888((uint32_t *)cam_fb, (uint32_t *)lcd_fb);
 	//frameCounter++;
 }
 
@@ -61,7 +58,7 @@ BSP_CAMERA_VsyncEventCallback(void) {
 //}
 
 void BSP_CAMERA_FrameEventCallback(void) {
-	//LCD_DMA_Transfer_RGBTOARGB8888((uint32_t *)(CAMERA_FRAME_BUFFER), (uint32_t *)(LCD_FRAME_BUFFER));
+	//LCD_DMA_Transfer_RGBTOARGB8888((uint32_t *)(cam_fb), (uint32_t *)(lcd_fb));
 	//printf("\nFrame Event Callback\n");
 }
 
@@ -70,7 +67,7 @@ void BSP_CAMERA_FrameEventCallback(void) {
 //  static uint32_t tmp, tmp2, counter;
 //  if(272 > counter)
 //  {
-//    LCD_LL_ConvertLineToARGB8888((uint32_t *)(CAMERA_FRAME_BUFFER + tmp), (uint32_t *)(LCD_FRAME_BUFFER + tmp2));
+//    LCD_LL_ConvertLineToARGB8888((uint32_t *)(cam_fb + tmp), (uint32_t *)(lcd_fb + tmp2));
 //    tmp  = tmp + 480*sizeof(uint16_t);
 //    tmp2 = tmp2 + (480) * sizeof(uint32_t);
 //    counter++;
@@ -78,7 +75,7 @@ void BSP_CAMERA_FrameEventCallback(void) {
 //  else
 //  {
 //	//FRAME Event//
-//	//LCD_DMA_Transfer_RGBTOARGB8888((uint32_t *)(CAMERA_FRAME_BUFFER), (uint32_t *)(LCD_FRAME_BUFFER));
+//	//LCD_DMA_Transfer_RGBTOARGB8888((uint32_t *)(cam_fb), (uint32_t *)(lcd_fb));
 //    tmp = 0;
 //    tmp2 = 0;
 //    counter = 0;

--- a/STM32F746NGHX_FLASH.ld
+++ b/STM32F746NGHX_FLASH.ld
@@ -47,6 +47,7 @@ MEMORY
   DTCM     (rw)   : ORIGIN = 0x20000000,   LENGTH = 64K
   RAM    (xrw)    : ORIGIN = 0x20010000,   LENGTH = 256K
   FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 1024K
+  SDRAM    (rw)   : ORIGIN = 0xc0000000,   LENGTH = 64M
 }
 
 /* Sections */
@@ -174,6 +175,18 @@ SECTIONS
     _ebss = .;         /* define a global symbol at bss end */
     __bss_end__ = _ebss;
   } >RAM
+
+  /* .sdram region for external SDRAM. Data will only be placed in here explicitly */
+  .sdram : 
+  {
+    . = ALIGN(4);
+    _sdtcm = .;        /* create a global symbol at data start */
+    *(.sdram)           /* .data sections */
+    *(.sdram*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edtcm = .;        /* define a global symbol at data end */
+  } >SDRAM
 
   /* User_heap_stack section, used to check that there is enough "RAM" Ram  type memory left */
   ._user_heap_stack :

--- a/STM32F746NGHX_FLASH.ld
+++ b/STM32F746NGHX_FLASH.ld
@@ -44,7 +44,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Memories definition */
 MEMORY
 {
-  RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 320K
+  DTCM     (rw)   : ORIGIN = 0x20000000,   LENGTH = 64K
+  RAM    (xrw)    : ORIGIN = 0x20010000,   LENGTH = 256K
   FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 1024K
 }
 
@@ -145,6 +146,18 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
 
   } >RAM AT> FLASH
+
+  /* .dtcm region for tightly-coupled data memory. Data will only be placed in here explicitly */
+  .dtcm : 
+  {
+    . = ALIGN(4);
+    _sdtcm = .;        /* create a global symbol at data start */
+    *(.dtcm)           /* .data sections */
+    *(.dtcm*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edtcm = .;        /* define a global symbol at data end */
+  } >DTCM AT> RAM
 
   /* Uninitialized data section into "RAM" Ram type memory */
   . = ALIGN(4);

--- a/STM32F746NGHX_RAM.ld
+++ b/STM32F746NGHX_RAM.ld
@@ -47,6 +47,7 @@ MEMORY
   DTCM     (rw)   : ORIGIN = 0x20000000,   LENGTH = 64K
   RAM    (xrw)    : ORIGIN = 0x20010000,   LENGTH = 256K
   FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 1024K
+  SDRAM    (rw)   : ORIGIN = 0xc0000000,   LENGTH = 64M
 }
 
 /* Sections */
@@ -174,6 +175,18 @@ SECTIONS
     _ebss = .;         /* define a global symbol at bss end */
     __bss_end__ = _ebss;
   } >RAM
+
+  /* .sdram region for external SDRAM. Data will only be placed in here explicitly */
+  .sdram : 
+  {
+    . = ALIGN(4);
+    _sdtcm = .;        /* create a global symbol at data start */
+    *(.sdram)           /* .data sections */
+    *(.sdram*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edtcm = .;        /* define a global symbol at data end */
+  } >SDRAM
 
   /* User_heap_stack section, used to check that there is enough "RAM" Ram  type memory left */
   ._user_heap_stack :

--- a/STM32F746NGHX_RAM.ld
+++ b/STM32F746NGHX_RAM.ld
@@ -44,7 +44,8 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Memories definition */
 MEMORY
 {
-  RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 320K
+  DTCM     (rw)   : ORIGIN = 0x20000000,   LENGTH = 64K
+  RAM    (xrw)    : ORIGIN = 0x20010000,   LENGTH = 256K
   FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 1024K
 }
 
@@ -145,6 +146,18 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
 
   } >RAM
+
+  /* .dtcm region for tightly-coupled data memory. Data will only be placed in here explicitly */
+  .dtcm : 
+  {
+    . = ALIGN(4);
+    _sdtcm = .;        /* create a global symbol at data start */
+    *(.dtcm)           /* .data sections */
+    *(.dtcm*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edtcm = .;        /* define a global symbol at data end */
+  } >DTCM AT> RAM
 
   /* Uninitialized data section into "RAM" Ram type memory */
   . = ALIGN(4);


### PR DESCRIPTION
Add external RAM and DTCM to linker script. Store variables on external RAM using compiler attributes rather than explicit addresses. This centralises logic and lessens chance of double-allocation.